### PR TITLE
DEFAULT_WORKER_SRC version now matches pdfjs-dist version

### DIFF
--- a/src/components/PdfLoader.tsx
+++ b/src/components/PdfLoader.tsx
@@ -1,7 +1,19 @@
 import React, { ReactNode, useEffect, useRef, useState } from "react";
 
-import { GlobalWorkerOptions, OnProgressParameters, getDocument, type PDFDocumentLoadingTask, type PDFDocumentProxy } from "pdfjs-dist";
-import { DocumentInitParameters, TypedArray } from "pdfjs-dist/types/src/display/api";
+import {
+  GlobalWorkerOptions,
+  OnProgressParameters,
+  getDocument,
+  type PDFDocumentLoadingTask,
+  type PDFDocumentProxy,
+} from "pdfjs-dist";
+import {
+  DocumentInitParameters,
+  TypedArray,
+} from "pdfjs-dist/types/src/display/api";
+
+// Get the version of pdfjs-dist we are using so that the default worker source can be set to match.
+import { version } from "pdfjs-dist/build/pdf.mjs";
 
 const DEFAULT_BEFORE_LOAD = (progress: OnProgressParameters) => (
   <div style={{ color: "black" }}>
@@ -17,8 +29,8 @@ const DEFAULT_ON_ERROR = (error: Error) => {
   throw new Error(`Error loading PDF document: ${error.message}!`);
 };
 
-const DEFAULT_WORKER_SRC =
-  "https://unpkg.com/pdfjs-dist@4.4.168/build/pdf.worker.min.mjs";
+// Version defaults to the version of pdfjs-dist we have installed.
+const DEFAULT_WORKER_SRC = `https://unpkg.com/pdfjs-dist@${version}/build/pdf.worker.min.mjs-asdfasdf`;
 
 /**
  * The props type for {@link PdfLoader}.
@@ -128,6 +140,6 @@ export const PdfLoader = ({
   return error
     ? errorMessage(error)
     : loadingProgress
-      ? beforeLoad(loadingProgress)
-      : pdfDocumentRef.current && children(pdfDocumentRef.current);
+    ? beforeLoad(loadingProgress)
+    : pdfDocumentRef.current && children(pdfDocumentRef.current);
 };


### PR DESCRIPTION
If the workerSrc version and the pdfjs-dist version are mismatched, the following error will occur:

```
The API version "4.5.136" does not match the Worker version "4.4.168".
```

This error may occur whenever npm installs the latest incremental version of pdfjs-dist that has an API incompatibility with the worker version.

This change ensures the default workerSrc version matches the pdfjs-dist version.

### Main Changes:

See lines 15 / 16 and 32 / 33. Sorry for the formatter changes.