### PR TITLE
Display PDF forms as read-only - Pass options down to PDF.js PDFViewer

### DIFF
--- a/src/components/PdfHighlighter.tsx
+++ b/src/components/PdfHighlighter.tsx
@@ -42,6 +42,7 @@ import { HighlightLayer } from "./HighlightLayer";
 import { MouseSelection } from "./MouseSelection";
 import { TipContainer } from "./TipContainer";
 
+import type { PDFViewerOptions } from "pdfjs-dist/types/web/pdf_viewer";
 import type { EventBus as TEventBus, PDFLinkService as TPDFLinkService, PDFViewer as TPDFViewer } from "pdfjs-dist/web/pdf_viewer.mjs";
 
 let EventBus: typeof TEventBus, PDFLinkService: typeof TPDFLinkService, PDFViewer: typeof TPDFViewer;
@@ -166,6 +167,11 @@ export interface PdfHighlighterProps {
    * other style props like `textSelectionColor` or overwrite pdf_viewer.css
    */
   style?: CSSProperties;
+
+  /**
+   * Options passed down to the PDF.js PDFViewer.
+   */
+  pdfViewerOptions?: Omit<PDFViewerOptions, "container" | "eventBus" | "linkService">
 }
 
 /**
@@ -193,6 +199,7 @@ export const PdfHighlighter = ({
   textSelectionColor = DEFAULT_TEXT_SELECTION_COLOR,
   utilsRef,
   style,
+  pdfViewerOptions,
 }: PdfHighlighterProps) => {
   // State
   const [tip, setTip] = useState<Tip | null>(null);
@@ -233,6 +240,7 @@ export const PdfHighlighter = ({
           textLayerMode: 2,
           removePageBorders: true,
           linkService: linkServiceRef.current,
+          ...pdfViewerOptions,
         });
 
       viewerRef.current.setDocument(pdfDocument);


### PR DESCRIPTION
By default PDF.js renders forms in the document with normal  `<input />`  elements, this gets confusing for users as those annotations have nothing to do with the react highlights yet it seems you can edit and change those.

PDF.js supports toggling how forms are rendered with the `annotationMode` option, in my case I wanted it to be mode 1, enabled but not as input elements.
https://github.com/mozilla/pdf.js/blob/aa2337f934d6e0b4ce9b8bfb45030fedbe3f01f4/src/shared/util.js#L65

This PR allows passing options like this down to the PDFViewer of PDF.js.

I figured I might as well let other options be passed down too, I explicitly omitted the container/eventBus/linkService from the props type to hint that those are set internally.