### PR TITLE
Draft: Bypass rotation issues

### DIFF
--- a/src/components/PdfHighlighter.tsx
+++ b/src/components/PdfHighlighter.tsx
@@ -397,9 +397,10 @@ export const PdfHighlighter = ({
       if (highlightBindings?.container?.isConnected) {
         renderHighlightLayer(highlightBindings, pageNumber);
       } else {
-        const { textLayer } =
+        const { annotationLayer: textLayer } =
           viewerRef.current!.getPageView(pageNumber - 1) || {};
         if (!textLayer) continue; // Viewer hasn't rendered page yet
+        if (!textLayer.div) continue;
 
         // textLayer.div for version >=3.0 and textLayer.textLayerDiv otherwise.
         const highlightLayer = findOrCreateHighlightLayer(

--- a/src/components/PdfHighlighter.tsx
+++ b/src/components/PdfHighlighter.tsx
@@ -397,7 +397,7 @@ export const PdfHighlighter = ({
       if (highlightBindings?.container?.isConnected) {
         renderHighlightLayer(highlightBindings, pageNumber);
       } else {
-        const { annotationLayer: textLayer } =
+        const { textLayer } =
           viewerRef.current!.getPageView(pageNumber - 1) || {};
         if (!textLayer) continue; // Viewer hasn't rendered page yet
         if (!textLayer.div) continue;

--- a/src/lib/pdfjs-dom.ts
+++ b/src/lib/pdfjs-dom.ts
@@ -75,11 +75,16 @@ export const findOrCreateContainerLayer = (
   container: HTMLElement,
   className: string,
 ) => {
+  // Ensure container is not hidden
+  // TODO: Figure out why it would be
+  container.hidden = false;
+
   const doc = getDocument(container);
   let layer = container.querySelector(`.${className}`);
 
   // To ensure predictable zIndexing, wait until the pdfjs element has children.
-  if (!layer && container.children.length) {
+  // if (!layer && container.children.length) {
+  if (!layer) {
     layer = doc.createElement("div");
     layer.className = className;
     container.appendChild(layer);

--- a/src/lib/pdfjs-dom.ts
+++ b/src/lib/pdfjs-dom.ts
@@ -71,23 +71,43 @@ export const getPagesFromRange = (range: Range): Page[] => {
   return pages as Page[];
 };
 
+
+/**
+ * Create a container element we can use for highlights.
+ * The original textLayer will be rotated by CSS to match
+ * the rotation of individual PDF pages - this is not desired.
+ * To keep our highlights independent of text rotation
+ * we add a dedicated div to hold our annotations as a sibling.
+ * The main styling is copied over, but we omit the
+ * `data-main-rotation` attribute to keep our container div
+ * from being rotated.
+ *
+ * @param container The original textLayer div from PDF.js
+ */
 export const findOrCreateContainerLayer = (
   container: HTMLElement,
   className: string,
 ) => {
-  // Ensure container is not hidden
-  // TODO: Figure out why it would be
-  container.hidden = false;
+  // Grab the parent - same div that hold the textLayer
+  let pageDiv = container.parentElement;
+  if (pageDiv === null) {
+    return null;
+  }
 
   const doc = getDocument(container);
-  let layer = container.querySelector(`.${className}`);
+  let layer = pageDiv.querySelector(`.${className}`);
 
-  // To ensure predictable zIndexing, wait until the pdfjs element has children.
-  // if (!layer && container.children.length) {
+  // TODO: There used to be concern about z-indexing
+  //       here when adding to textLayer div, still relevant?
   if (!layer) {
     layer = doc.createElement("div");
-    layer.className = className;
-    container.appendChild(layer);
+    // Add the PDF.js textLayer class to get styled similarly
+    layer.className = `${className} textLayer`;
+
+    // TODO: Is this needed or purely for rotation?
+    //layer.style.cssText = container.style.cssText;
+
+    pageDiv.appendChild(layer);
   }
 
   return layer;


### PR DESCRIPTION
This is an alternative approach to #27 #28 

Instead of trying to avoid and dodge rotation all over, just render highlights in a div where they don't get rotated in the first place.

This is a bit hacky to illustrate the approach, but try to create area highlights against the rotated pdf example document - it will work correctly on this branch, similarly the "top-left" highlight is actually top left on all documents.

Is this the right approach? I'm still not sure, but I think this behavior should at least be possible and this way of using an unrotated div is way cleaner than in #28