### PR TITLE
Customize scroll handler re-addition within scrollToHighlight

### DIFF
--- a/src/components/PdfHighlighter.tsx
+++ b/src/components/PdfHighlighter.tsx
@@ -464,7 +464,14 @@ export const PdfHighlighter = ({
     selection.removeAllRanges();
   };
 
-  const scrollToHighlight = (highlight: Highlight) => {
+  /**
+   * Scrolls to a highlight and highlights it with TextHighlight__part style. 
+   * Removes the scroll listener and re-adds it after the highlight is scrolled to after a specified timeout.
+   * 
+   * @param highlight - The highlight to scroll to.
+   * @param scrollListenerTimeout - The timeout for the scroll listener.
+   */
+  const scrollToHighlight = (highlight: Highlight, scrollListenerTimeout = 100) => {
     const { boundingRect, usePdfCoordinates } = highlight.position;
     const pageNumber = boundingRect.pageNumber;
 
@@ -497,7 +504,7 @@ export const PdfHighlighter = ({
       viewerRef.current!.container.addEventListener("scroll", handleScroll, {
         once: true,
       });
-    }, 100);
+    }, scrollListenerTimeout);
   };
 
   const pdfHighlighterUtils: PdfHighlighterUtils = {

--- a/src/contexts/PdfHighlighterContext.ts
+++ b/src/contexts/PdfHighlighterContext.ts
@@ -57,11 +57,13 @@ export type PdfHighlighterUtils = {
 
   /**
    * Scroll to a highlight in this viewer.
-   *
+   * Removes the scroll listener during scrolling and re-adds it after the highlight is scrolled to after a specified timeout.
+   * 
    * @param highlight - A highlight provided to the {@link PdfHighlighter} to
    * scroll to.
+   * @param scrollListenerTimeout - The timeout for the scroll listener.
    */
-  scrollToHighlight(highlight: Highlight): void;
+  scrollToHighlight(highlight: Highlight, scrollListenerTimeout?: number): void;
 
   /**
    * Get a reference to the currently used instance of a PDF Viewer.


### PR DESCRIPTION
Adds a configurable timeout to customize how long the scroll handler is removed from the PdfViewer during a scrollToHighlight call.

Original value of 100 ms is too short for me when I wanted to enable smooth scrolling for the PdfViewer from PDF.js via adding the css property `scroll-behavior: smooth` to the `PdfHighlighter` css class.

Ideally one would use the [scrollend](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event) event to know exactly when to add the scroll handler back via a hook, but the event has limited availability on browsers (isn't supported on Safari at all).

Hopefully it's a quick review! Great project, I appreciate the time you put into this.