### PR TITLE
fix creating multiple text highlight elements each instance

### DIFF
--- a/src/lib/group-highlights-by-page.ts
+++ b/src/lib/group-highlights-by-page.ts
@@ -17,8 +17,7 @@ const groupHighlightsByPage = (
       ...highlight.position.rects.map((rect) => rect.pageNumber || 0),
     ];
 
-    // remove potential duplicate page numbers due from
-    // text highlights
+    // remove potential duplicate page numbers from text highlights
     const uniquePageNumbers = new Set(pageNumbers);
 
     uniquePageNumbers.forEach((pageNumber) => {

--- a/src/lib/group-highlights-by-page.ts
+++ b/src/lib/group-highlights-by-page.ts
@@ -5,25 +5,30 @@ type GroupedHighlights = {
 };
 
 const groupHighlightsByPage = (
-  highlights: Array<Highlight | GhostHighlight | null>,
+  highlights: Array<Highlight | GhostHighlight | null>
 ): GroupedHighlights =>
   highlights.reduce<GroupedHighlights>((acc, highlight) => {
     if (!highlight) {
       return acc;
     }
+
     const pageNumbers = [
       highlight.position.boundingRect.pageNumber,
       ...highlight.position.rects.map((rect) => rect.pageNumber || 0),
     ];
 
-    pageNumbers.forEach((pageNumber) => {
+    // remove potential duplicate page numbers due from
+    // text highlights
+    const uniquePageNumbers = new Set(pageNumbers);
+
+    uniquePageNumbers.forEach((pageNumber) => {
       acc[pageNumber] ||= [];
       const pageSpecificHighlight = {
         ...highlight,
         position: {
           ...highlight.position,
           rects: highlight.position.rects.filter(
-            (rect) => pageNumber === rect.pageNumber,
+            (rect) => pageNumber === rect.pageNumber
           ),
         },
       };


### PR DESCRIPTION
Current:
<img width="882" alt="Untitled (1)" src="https://github.com/user-attachments/assets/19eec900-968e-4ba9-a823-60a3f13ca8a1" />

Each text box highlight is getting counted multiple times when grouping highlights by page. This means that if you highlight 5 lines of text, then it will create the nested divs 5x instead of the single time that it should.

I just created a set to make sure that text elements don't get counted multiple times. 

Fixed:
<img width="1642" alt="Untitled (2)" src="https://github.com/user-attachments/assets/8bd2f030-e901-4826-b555-d72ca39f0006" />
